### PR TITLE
Fix: make postgres driver import local instead of broad.

### DIFF
--- a/queryzen-api/databases/base.py
+++ b/queryzen-api/databases/base.py
@@ -6,7 +6,6 @@ import logging
 import re
 
 import sqlite3
-import psycopg2
 
 import httpx
 
@@ -156,6 +155,13 @@ class PostgresDatabase(Database):
     """PostgresSQL"""
 
     def __init__(self, database, user, password, host, port, *args, **kwargs):
+        try:
+            import psycopg2 # pylint: disable=C0415
+        except ModuleNotFoundError as e:
+            raise Exception( # pylint: disable=W0719 broad-exception
+                f"Trying to use {self!r} without the appropriate driver installed"
+            ) from e
+
         self.connection = psycopg2.connect(
             dbname=database,
             user=user,


### PR DESCRIPTION
If a user is not using postgres, the worker will not start since they won't have psycopg2 installed, in future iterations we'll have to make drivers per-installation, and not install every driver.

This is not a problem in CrateDB since we are not using any driver now (we should change this in the future), we are just using the bare HTTP endpoint.